### PR TITLE
fix pipeline

### DIFF
--- a/.github/workflows/pipeline-ai-impact-pullrequest.yml
+++ b/.github/workflows/pipeline-ai-impact-pullrequest.yml
@@ -55,17 +55,17 @@ jobs:
           JOB_ID=$(echo $RESPONSE)
           echo "job_id=$JOB_ID" >> $GITHUB_ENV
 
-          - name: Monitor Code Review Job Status
-          id: monitor_code_review_status
-          run: |
-            JOB_ID=${{ env.job_id }}
-            STATUS="Pending"
-            while [[ "$STATUS" != "Completed" ]]; do
-              RESPONSE=$(curl --location "http://api.gftaiimpact.local/ai/jobs/$JOB_ID/status" \
-                --header "Authorization: Bearer ${{ env.access_token }}")
-              STATUS=$(echo $RESPONSE | jq -r '.status')
-              echo "Current status: $STATUS"
-              sleep 10
-            done
-            echo "Final status: $STATUS"
+      - name: Monitor Code Review Job Status
+        id: monitor_code_review_status
+        run: |
+          JOB_ID=${{ env.job_id }}
+          STATUS="Pending"
+          while [[ "$STATUS" != "Completed" ]]; do
+            RESPONSE=$(curl --location "http://api.gftaiimpact.local/ai/jobs/$JOB_ID/status" \
+              --header "Authorization: Bearer ${{ env.access_token }}")
+            STATUS=$(echo $RESPONSE | jq -r '.status')
+            echo "Current status: $STATUS"
+            sleep 10
+          done
+          echo "Final status: $STATUS"
 

--- a/.github/workflows/pipeline-ai-impact-pullrequest.yml
+++ b/.github/workflows/pipeline-ai-impact-pullrequest.yml
@@ -68,13 +68,4 @@ jobs:
               sleep 10
             done
             echo "Final status: $STATUS"
-            OUTPUT_URIS=$(echo "$RESPONSE" | jq -r '.results[].output[].uri')
-  
-            echo "job_response=$RESPONSE" >> "$GITHUB_ENV"
-  
-            {
-              echo "output_uris<<EOF"
-              echo "$OUTPUT_URIS"
-              echo "EOF"
-            } >> "$GITHUB_ENV"
 


### PR DESCRIPTION
# ![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Generated for GFT AI Impact Bot for the f8c857b0a1c25e06c768b63a9a777c220005cc60

**Description:** This pull request modifies the GitHub Actions workflow file `pipeline-ai-impact-pullrequest.yml`. The changes simplify the logic for monitoring the status of a code review job by removing the handling of output URIs and job response storage in the environment variables. The updated code focuses solely on monitoring the job status until completion.

**Summary:** 
- **File Modified:** `.github/workflows/pipeline-ai-impact-pullrequest.yml`
  - Removed the logic for storing job response and output URIs in environment variables.
  - Simplified the monitoring loop to focus only on checking the job status until it reaches "Completed".
  - Removed the block that writes `job_response` and `output_uris` to the environment variables.

**Recommendation:** 
1. **Code Quality:** While the simplification improves readability, the removal of `job_response` and `output_uris` storage may limit debugging capabilities or downstream usage of these values. If these values are required for other steps in the pipeline, consider reintroducing them with proper documentation on their usage.
2. **Error Handling:** The current implementation does not handle cases where the API call fails (e.g., network issues or invalid `JOB_ID`). Add error handling to ensure the script does not enter an infinite loop or fail silently. For example:
   ```bash
   RESPONSE=$(curl --location "http://api.gftaiimpact.local/ai/jobs/$JOB_ID/status" \
     --header "Authorization: Bearer ${{ env.access_token }}" || echo "error")
   if [[ "$RESPONSE" == "error" ]]; then
     echo "Error fetching job status. Exiting."
     exit 1
   fi
   ```
3. **Timeout Mechanism:** Introduce a timeout mechanism to prevent the script from running indefinitely if the job status does not change to "Completed". For example:
   ```bash
   MAX_RETRIES=30
   RETRY_COUNT=0
   while [[ "$STATUS" != "Completed" && $RETRY_COUNT -lt $MAX_RETRIES ]]; do
     # existing logic
     RETRY_COUNT=$((RETRY_COUNT + 1))
   done
   if [[ $RETRY_COUNT -ge $MAX_RETRIES ]]; then
     echo "Job monitoring timed out. Exiting."
     exit 1
   fi
   ```

**Explanation of vulnerabilities:** 
1. **Hardcoded API URL:** The API URL `http://api.gftaiimpact.local/ai/jobs/$JOB_ID/status` is hardcoded, which could lead to issues if the environment changes or the URL is incorrect. Use environment variables or configuration files to make the URL configurable.
   - Suggested fix:
     ```bash
     API_URL=${{ env.api_url }}
     RESPONSE=$(curl --location "$API_URL/ai/jobs/$JOB_ID/status" \
       --header "Authorization: Bearer ${{ env.access_token }}")
     ```
2. **Authorization Token Exposure:** The authorization token `${{ env.access_token }}` is passed directly in the header. Ensure that this token is securely stored and rotated periodically to prevent unauthorized access.
3. **Lack of Validation for API Response:** The script assumes the API response will always contain a valid `status` field. If the API changes or returns an error, the script may fail unexpectedly. Add validation to check the structure of the response before extracting the `status`.

By addressing these recommendations and vulnerabilities, the workflow can be made more robust and secure.