### PR TITLE
[GFTCodeFixer]:  Update on src/main/java/com/scalesec/vulnado/LinkLister.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/LinkLister.java
+++ b/src/main/java/com/scalesec/vulnado/LinkLister.java
@@ -1,3 +1,26 @@
+To address the remarks from SonarQube, we will make the following changes:
+
+### Analysis and Fixes:
+
+#### [13]: 
+- **[ISSUE](java:S1118)**: Add a private constructor to hide the implicit public one.
+  - The `LinkLister` class is a utility class with only static methods. To prevent instantiation, we need to add a private constructor.
+
+#### [15]: 
+- **[ISSUE](java:S2293)**: Replace the type specification in this constructor call with the diamond operator ("<>").
+  - The `new ArrayList<String>()` can be simplified to `new ArrayList<>()` using the diamond operator.
+
+#### [28]: 
+- **[ISSUE](java:S106)**: Replace this use of `System.out` by a logger.
+  - Replace `System.out.println(host);` with a proper logging mechanism. Since no logger is currently declared, we will add one.
+
+---
+
+### Code Changes:
+
+Here is the updated code with the necessary fixes:
+
+```java
 package com.scalesec.vulnado;
 
 import org.jsoup.Jsoup;
@@ -8,11 +31,17 @@ import java.util.ArrayList;
 import java.util.List;
 import java.io.IOException;
 import java.net.*;
-
+import java.util.logging.Logger;
 
 public class LinkLister {
+  private static final Logger LOGGER = Logger.getLogger(LinkLister.class.getName());
+
+  private LinkLister() {
+    // Private constructor to prevent instantiation
+  }
+
   public static List<String> getLinks(String url) throws IOException {
-    List<String> result = new ArrayList<String>();
+    List<String> result = new ArrayList<>();
     Document doc = Jsoup.connect(url).get();
     Elements links = doc.select("a");
     for (Element link : links) {
@@ -23,16 +52,79 @@ public class LinkLister {
 
   public static List<String> getLinksV2(String url) throws BadRequest {
     try {
-      URL aUrl= new URL(url);
+      URL aUrl = new URL(url);
       String host = aUrl.getHost();
-      System.out.println(host);
-      if (host.startsWith("172.") || host.startsWith("192.168") || host.startsWith("10.")){
+      LOGGER.info(host);
+      if (host.startsWith("172.") || host.startsWith("192.168") || host.startsWith("10.")) {
         throw new BadRequest("Use of Private IP");
       } else {
         return getLinks(url);
       }
-    } catch(Exception e) {
+    } catch (Exception e) {
       throw new BadRequest(e.getMessage());
     }
   }
 }
+```
+
+---
+
+### Explanation of Changes:
+1. **[13]**: Added a private constructor to the `LinkLister` class to prevent instantiation.
+2. **[15]**: Replaced `new ArrayList<String>()` with `new ArrayList<>()` to use the diamond operator.
+3. **[28]**: 
+   - Added a `Logger` instance (`LOGGER`) to the class.
+   - Replaced `System.out.println(host);` with `LOGGER.info(host);`.
+
+---
+
+### ContentEditor Operations:
+
+```json
+{
+  "operations": [
+    {
+      "operation": "INSERT",
+      "lineNumber": 10,
+      "content": "import java.util.logging.Logger;"
+    },
+    {
+      "operation": "INSERT",
+      "lineNumber": 12,
+      "content": "private static final Logger LOGGER = Logger.getLogger(LinkLister.class.getName());"
+    },
+    {
+      "operation": "INSERT",
+      "lineNumber": 14,
+      "content": "private LinkLister() {"
+    },
+    {
+      "operation": "INSERT",
+      "lineNumber": 15,
+      "content": "// Private constructor to prevent instantiation"
+    },
+    {
+      "operation": "INSERT",
+      "lineNumber": 16,
+      "content": "}"
+    },
+    {
+      "operation": "REPLACE",
+      "lineNumber": 15,
+      "content": "List<String> result = new ArrayList<>();"
+    },
+    {
+      "operation": "REPLACE",
+      "lineNumber": 28,
+      "content": "LOGGER.info(host);"
+    }
+  ]
+}
+```
+
+---
+
+### Summary:
+- The `LinkLister` class is now a proper utility class with a private constructor.
+- The diamond operator is used for type inference in the `ArrayList` instantiation.
+- Logging is implemented using `java.util.logging.Logger` instead of `System.out.println`.


### PR DESCRIPTION
# ![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Generated for GFT AI Impact Bot for the d2947c9217c673a82443c5eadd5f4b89fcfa333f

**Description:** This pull request addresses several issues flagged by SonarQube in the `LinkLister` class. The changes include making the class a proper utility class by adding a private constructor, improving type inference with the diamond operator, and replacing `System.out.println` with a proper logging mechanism using `java.util.logging.Logger`.

**Summary:**  
- **File Modified:** `src/main/java/com/scalesec/vulnado/LinkLister.java`  
  - **Added:** A private constructor to prevent instantiation of the utility class.  
  - **Replaced:** `new ArrayList<String>()` with `new ArrayList<>()` to use the diamond operator for type inference.  
  - **Added:** A `Logger` instance (`LOGGER`) to replace `System.out.println` for logging.  
  - **Replaced:** `System.out.println(host);` with `LOGGER.info(host);`.  

**Recommendation:**  
1. **Logging Configuration:** Ensure that the `Logger` is properly configured in the application to avoid excessive or unformatted log output. Consider using a logging framework like SLF4J with Logback for better flexibility and configuration options.  
2. **Error Handling:** The `catch` block in the `getLinksV2` method uses a generic `Exception`. It is recommended to catch specific exceptions to avoid masking unexpected errors. For example, catching `MalformedURLException` or `IOException` separately would make the code more robust.  
3. **Validation:** The `getLinksV2` method checks for private IPs using hardcoded prefixes (`172.`, `192.168`, `10.`). Consider using a library or utility method to validate private IPs more comprehensively, as this approach may miss edge cases.  

**Explanation of vulnerabilities:**  
1. **Hardcoded IP Validation:**  
   - The current implementation checks for private IPs using hardcoded prefixes. This approach is prone to errors and may not cover all private IP ranges (e.g., `127.0.0.1` for localhost).  
   - **Suggested Fix:** Use a library like Apache Commons Net's `SubnetUtils` or implement a utility method to validate private IPs more accurately.  
   - Example:  
     ```java
     private boolean isPrivateIP(String ip) {
         return ip.startsWith("172.") || ip.startsWith("192.168") || ip.startsWith("10.") || ip.equals("127.0.0.1");
     }
     ```
2. **Generic Exception Handling:**  
   - Catching a generic `Exception` in the `getLinksV2` method can lead to unintended behavior, as it may mask critical errors.  
   - **Suggested Fix:** Catch specific exceptions like `MalformedURLException` or `IOException` to handle errors more precisely.  
   - Example:  
     ```java
     try {
         URL aUrl = new URL(url);
         String host = aUrl.getHost();
         LOGGER.info(host);
         if (isPrivateIP(host)) {
             throw new BadRequest("Use of Private IP");
         } else {
             return getLinks(url);
         }
     } catch (MalformedURLException e) {
         throw new BadRequest("Invalid URL format: " + e.getMessage());
     } catch (IOException e) {
         throw new BadRequest("Error connecting to URL: " + e.getMessage());
     }
     ```

By addressing these vulnerabilities, the code will be more secure and maintainable.